### PR TITLE
Integrating Google Picker inside "insert" menu

### DIFF
--- a/easy-doc/src/App.js
+++ b/easy-doc/src/App.js
@@ -42,9 +42,6 @@ class App extends Component {
 							<div className='text-editor'>
 								<TextEditor text={this.state.translatedText} />
 							</div>
-							<div className='test'>
-								<GoogleDrivePicker />
-							</div>
 						</div>
 					</Route>
 				</Switch>

--- a/easy-doc/src/components/GoogleDrivePicker.js
+++ b/easy-doc/src/components/GoogleDrivePicker.js
@@ -56,7 +56,7 @@ class GoogleDrivePicker extends React.Component {
             picker.build().setVisible(true);
           }}
         >
-          <Button type="submit">Google</Button>
+          <Button variant="light">Google Drive</Button>
         </GooglePicker>
       </div>
     )

--- a/easy-doc/src/components/GoogleDrivePicker.js
+++ b/easy-doc/src/components/GoogleDrivePicker.js
@@ -61,7 +61,6 @@ class GoogleDrivePicker extends React.Component {
             className='dropdowns'>
             Google
           </Dropdown.Item>
-          {/* <Button variant="light">Google Drive</Button> */}
         </GooglePicker>
       </div>
     )

--- a/easy-doc/src/components/GoogleDrivePicker.js
+++ b/easy-doc/src/components/GoogleDrivePicker.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button'
 import GooglePicker from 'react-google-picker';
+import Dropdown from 'react-bootstrap/Dropdown';
 
 /**
  * File picker to select items from Google Drive.
@@ -56,7 +57,11 @@ class GoogleDrivePicker extends React.Component {
             picker.build().setVisible(true);
           }}
         >
-          <Button variant="light">Google Drive</Button>
+          <Dropdown.Item
+            className='dropdowns'>
+            Google
+          </Dropdown.Item>
+          {/* <Button variant="light">Google Drive</Button> */}
         </GooglePicker>
       </div>
     )

--- a/easy-doc/src/components/TopNavbar.js
+++ b/easy-doc/src/components/TopNavbar.js
@@ -7,6 +7,7 @@ import Form from 'react-bootstrap/Form';
 import Button from 'react-bootstrap/Button';
 import SpeechRecognition from './SpeechRecognition';
 import ImageFilePicker from './ImageFilePicker';
+import GoogleDrivePicker from './GoogleDrivePicker';
 
 /**
  * Top navigation bar for menu options.
@@ -34,16 +35,14 @@ class TopNavbar extends React.Component {
      * Calls the {@code SpeechToTextServlet} and converts speech to text.
      */
     this.convertSpeechToText = () => {
+      this.setState({ speechModalBoxShow: true })
       fetch('/speechtotext')
         .then((response) => response.text())
         .then((text) => {
           this.props.addTranslatedText(text);
-          // console.log(text);
           this.setState({ speechModalBoxShow: false });
         })
         .catch((error) => console.log(error));
-
-      this.setState({ speechModalBoxShow: true })
     };
   }
 
@@ -121,7 +120,7 @@ class TopNavbar extends React.Component {
                     </Dropdown.Item>
                     <Dropdown.Item
                       className='option3'>
-                      From Google Drive
+                      <GoogleDrivePicker />
                     </Dropdown.Item>
                   </Dropdown.Menu>
                 </Dropdown>


### PR DESCRIPTION
1. Removed a button below the text editor that previously opened Google Drive Picker. Now, the button is integrated inside the insert menu.
2. Changed the button classname to match with other options from the drop down menu.