### PR TITLE
Opens preview of image in another tab

### DIFF
--- a/easy-doc/public/index.html
+++ b/easy-doc/public/index.html
@@ -22,6 +22,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
   <title>Easy Docs</title>
+  <script src="https://apis.google.com/js/client.js"></script>
 </head>
 
 <body>

--- a/easy-doc/src/components/GoogleDrivePicker.js
+++ b/easy-doc/src/components/GoogleDrivePicker.js
@@ -13,9 +13,20 @@ class GoogleDrivePicker extends React.Component {
    */
   constructor(props) {
     super(props);
+    this.state = {
+      AUTH_TOKEN: ""
+    };
   }
 
-
+  /**
+   * Opens a new window to preview the image.
+   * 
+   * @param {data} fileId for the image. 
+   */
+  previewImage(data) {
+    let url = "https://drive.google.com/uc?export=view&id=" + data
+    window.open(url, '_blank').focus();
+  }
   /**
    * Renders navigation bar at the top of the webpage.
    *  @return { React.ReactNode } React virtual DOM.
@@ -35,6 +46,9 @@ class GoogleDrivePicker extends React.Component {
           developerKey={API_KEY}
           scope={scopes}
           onChange={data => console.log('on change:', data)}
+          onAuthenticate={token => {
+            this.setState({ AUTH_TOKEN: token });
+          }}
           onAuthFailed={data => console.log('on auth failed:', data)}
           navHidden={true}
           mimeTypes={["image/png", "image/jpeg", "image/jpg"]}
@@ -47,8 +61,7 @@ class GoogleDrivePicker extends React.Component {
               .setAppId(APP_ID)
               .setCallback((data) => {
                 if (data.action === google.picker.Action.PICKED) {
-                  var fileId = data.docs[0].id;
-                  alert("The user selected: " + fileId);
+                  this.previewImage(data.docs[0].id)
                 }
               })
               .enableFeature(google.picker.Feature.NAV_HIDDEN)


### PR DESCRIPTION
Instead of only displaying the file id, the image opens in a new tab of the same browser window.

TODO: display the image inside the text box.